### PR TITLE
initial appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,70 @@
+version: 0.1.0{build}
+image: Visual Studio 2017
+
+
+environment:
+  matrix:
+  - PlatformToolset: v141_xp
+    PLATFORM: x64
+
+  - PlatformToolset: v141_xp
+    PLATFORM: Win32
+
+configuration:
+    - Release
+    - Debug
+
+install:
+
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="x64" set platform_input=x64
+
+    - if "%platform%"=="Win32" set archi=x86
+    - if "%platform%"=="Win32" set platform_input=Win32
+
+    - if "%PlatformToolset%"=="v141_xp" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+    - if "%PlatformToolset%"=="v140_xp" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild linter.vcxproj /p:configuration="%configuration%" /p:platform="%platform_input%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - ps: >-
+
+        if ($env:PLATFORM_INPUT -eq "x64" -and $env:CONFIGURATION -eq "Release") {
+            Push-AppveyorArtifact "$env:PLATFORM_INPUT\$env:CONFIGURATION\linter.dll" -FileName linter.dll
+        }
+
+        if ($env:PLATFORM_INPUT -eq "Win32" -and $env:CONFIGURATION -eq "Release") {
+            Push-AppveyorArtifact "$env:CONFIGURATION\linter.dll" -FileName linter.dll
+        }
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v141_xp") {
+            if($env:PLATFORM_INPUT -eq "x64"){
+                $ZipFileName = "linter_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
+                7z a $ZipFileName $env:PLATFORM_INPUT\$env:CONFIGURATION\*.dll
+            }
+            if($env:PLATFORM_INPUT -eq "Win32"){
+                $ZipFileName = "linter_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
+                7z a $ZipFileName $env:CONFIGURATION\*.dll
+            }
+        }
+
+# artifacts:
+  # - path: linter_*.zip
+    # name: releases
+
+# deploy:
+    # provider: GitHub
+    # auth_token:
+        # secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    # artifact: releases
+    # draft: false
+    # prerelease: false
+    # force_update: true
+    # on:
+        # appveyor_repo_tag: true
+        # PlatformToolset: v141_xp
+        # configuration: Release Unicode


### PR DESCRIPTION
see build results at https://ci.appveyor.com/project/chcg/notepad-pp-linter

- post build scripts are not working as expected except of win32 release build
- seems there is no reason to exclude win xp users and therefore used toolset v141_xp (VS2017)
- could be also adapted to build for v140/v140_xp (VS2015)
- could be also used for automatic github release deployment on creating tags, see commented config at the end and https://www.appveyor.com/docs/deployment/github/#provider-settings