### PR TITLE
- update GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+ # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -7,14 +7,13 @@ jobs:
 
     runs-on: windows-latest
     strategy:
-      max-parallel: 4
       matrix:
         build_configuration: [Release, Debug]
         build_platform: [x64, Win32]
         
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1
@@ -25,14 +24,14 @@ jobs:
 
     - name: Archive artifacts for x64
       if: matrix.build_platform == 'x64' && matrix.build_configuration == 'Release'
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
           name: plugin_dll_x64
           path: ${{ matrix.build_platform }}\${{ matrix.build_configuration }}\linter.dll
 
     - name: Archive artifacts for Win32
       if: matrix.build_platform == 'Win32' && matrix.build_configuration == 'Release'
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
           name: plugin_dll_x86
           path: ${{ matrix.build_configuration }}\linter.dll

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,20 +16,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java
@@ -58,4 +49,4 @@ jobs:
       run: msbuild linter.vcxproj /m /p:configuration="Debug" /p:platform="x64" /p:PlatformToolset="v142"
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,13 @@
 version: 0.1.0{build}
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 
 environment:
   matrix:
-  - PlatformToolset: v141_xp
+  - PlatformToolset: v142
     PLATFORM: x64
 
-  - PlatformToolset: v141_xp
+  - PlatformToolset: v142
     PLATFORM: Win32
 
 configuration:
@@ -23,8 +23,8 @@ install:
     - if "%platform%"=="Win32" set platform_input=Win32
 
     - if "%PlatformToolset%"=="v141_xp" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
-    - if "%PlatformToolset%"=="v140_xp" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
     - if "%PlatformToolset%"=="v142"    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+    - if "%PlatformToolset%"=="v143"    call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
 
 build_script:
     - cd "%APPVEYOR_BUILD_FOLDER%"
@@ -42,7 +42,7 @@ after_build:
             Push-AppveyorArtifact "$env:CONFIGURATION\linter.dll" -FileName linter.dll
         }
 
-        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v141_xp") {
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v142") {
             if($env:PLATFORM_INPUT -eq "x64"){
                 $ZipFileName = "linter_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
                 7z a $ZipFileName "$($env:APPVEYOR_BUILD_FOLDER)\$env:PLATFORM_INPUT\$env:CONFIGURATION\*.dll"
@@ -67,5 +67,5 @@ after_build:
     # force_update: true
     # on:
         # appveyor_repo_tag: true
-        # PlatformToolset: v141_xp
+        # PlatformToolset: v142
         # configuration: Release


### PR DESCRIPTION
- added dependabot.yml to do a automatic check for updated actions
- updated appveyor.yml

It seems https://github.com/deadem/notepad-pp-linter/blob/master/linter.vcproj is obsolete in the meantime and could be removed.
If you are not using appveyor CI I think also that config seems to be not necessary.