### PR TITLE
Don't set alpha and colour to zero if not provided

### DIFF
--- a/XmlParser.cpp
+++ b/XmlParser.cpp
@@ -159,13 +159,13 @@ XmlParser::Settings XmlParser::getLinters(std::wstring file)
                 CComQIPtr<IXMLDOMElement> element(node);
 
                 CComVariant alpha;
-                if (SUCCEEDED(element->getAttribute(bstr_t(L"alpha"), &alpha)))
+                if (element->getAttribute(bstr_t(L"alpha"), &alpha) == S_OK)
                 {
                     std::wstringstream data(std::wstring(alpha.bstrVal ? alpha.bstrVal : L""));
                     data >> settings.m_alpha;
                 }
 
-                if (SUCCEEDED(element->getAttribute(bstr_t(L"color"), &alpha)))
+                if (element->getAttribute(bstr_t(L"color"), &alpha) == S_OK)
                 {
                     std::wstringstream data(std::wstring(alpha.bstrVal ? alpha.bstrVal : L""));
                     unsigned int color(0);


### PR DESCRIPTION
I noticed when playing around that if you set color in the style without an alpha, you got an alpha of zero, which made it very hard to see what was going on.

This appears to be down to the subtle difference between 'SUCCEEDED' and 'S_OK'.

I've changed this so that if you don't specify 'color' or 'alpha' it'll use the default color or alpha as appropriate.
