### PR TITLE
Refactor xmlparsers

### DIFF
--- a/DomDocument.cpp
+++ b/DomDocument.cpp
@@ -18,7 +18,7 @@ Linter::DomDocument::DomDocument(std::wstring const &filename)
     CComVariant value(bstrValue);
 
     VARIANT_BOOL resultCode = FALSE;
-    HRESULT hr = m_document->load(value, &resultCode);
+    HRESULT const hr = m_document->load(value, &resultCode);
 
     checkLoadResults(resultCode, hr);
 }
@@ -28,7 +28,7 @@ Linter::DomDocument::DomDocument(std::string const &xml)
     init();
 
     VARIANT_BOOL resultCode = FALSE;
-    HRESULT hr = m_document->loadXML(static_cast<_bstr_t>(xml.c_str()), &resultCode);
+    HRESULT const hr = m_document->loadXML(static_cast<_bstr_t>(xml.c_str()), &resultCode);
 
     checkLoadResults(resultCode, hr);
 }

--- a/DomDocument.cpp
+++ b/DomDocument.cpp
@@ -5,8 +5,8 @@
 #include "SystemError.h"
 #include "XmlDecodeException.h"
 
-#include <sstream>
 #include <stdexcept>
+#include <sstream>
 
 #pragma comment(lib, "msxml6.lib")
 

--- a/DomDocument.cpp
+++ b/DomDocument.cpp
@@ -1,0 +1,100 @@
+#include "stdafx.h"
+#include "DomDocument.h"
+
+#include "encoding.h"
+#include "SystemError.h"
+
+#include <sstream>
+#include <stdexcept>
+
+#pragma comment(lib, "msxml6.lib")
+
+namespace Linter
+{
+    DomDocument::DomDocument(std::wstring const &filename)
+    {
+        init();
+
+        BSTR bstrValue{bstr_t(filename.c_str())};
+        CComVariant value(bstrValue);
+
+        VARIANT_BOOL resultCode = FALSE;
+        HRESULT hr = m_document->load(value, &resultCode);
+
+        checkLoadResults(resultCode, hr, Encoding::toUTF(filename));
+    }
+
+    DomDocument::DomDocument(std::string const &xml)
+    {
+        init();
+
+        BSTR bstrValue{(bstr_t(xml.c_str()))};
+
+        VARIANT_BOOL resultCode = FALSE;
+        HRESULT hr = m_document->loadXML(bstrValue, &resultCode);
+
+        checkLoadResults(resultCode, hr, "temporary linter output file");
+    }
+
+    DomDocument::~DomDocument() = default;
+    
+    CComPtr<IXMLDOMNodeList> DomDocument::getNodeList(std::string const &xpath)
+    {
+        CComPtr<IXMLDOMNodeList> nodes;
+        HRESULT hr = m_document->selectNodes(bstr_t(xpath.c_str()), &nodes);
+        if (!SUCCEEDED(hr))
+        {
+            throw SystemError(hr, "Can't execute XPath " + xpath);
+        }
+        return nodes;
+    }
+
+    void DomDocument::init()
+    {
+        HRESULT hr = m_document.CoCreateInstance(__uuidof(DOMDocument));
+        if (!SUCCEEDED(hr))
+        {
+            throw SystemError(hr, "Can't create IID_IXMLDOMDocument2");
+        }
+
+        hr = m_document->put_async(VARIANT_FALSE);
+        if (!SUCCEEDED(hr))
+        {
+            throw SystemError(hr, "Can't XMLDOMDocument2::put_async");
+        }
+    }
+
+    void DomDocument::checkLoadResults(VARIANT_BOOL resultcode, HRESULT hr, std::string const &filename)
+    {
+        if (!SUCCEEDED(hr))
+        {
+            throw SystemError(hr);
+        }
+        if (resultcode != VARIANT_TRUE)
+        {
+            CComPtr<IXMLDOMParseError> error;
+            (void)m_document->get_parseError(&error);
+
+            if (error)
+            {
+                BSTR text;
+                error->get_srcText(&text);
+                BSTR reason;
+                error->get_reason(&reason);
+                long line;
+                error->get_line(&line);
+                long column;
+                error->get_linepos(&column);
+                std::ostringstream buff;
+                buff << "Invalid XML in " << filename << " at line " << line << " col " << column;
+                if (text != nullptr)
+                {
+                    buff << " (near " << static_cast<std::string>(static_cast<bstr_t>(text)) << ")";
+                }
+                buff << ": " << static_cast<std::string>(static_cast<bstr_t>(reason));
+                throw std::runtime_error(buff.str());
+            }
+        }
+    }
+
+}    // namespace Linter

--- a/DomDocument.cpp
+++ b/DomDocument.cpp
@@ -14,7 +14,7 @@ Linter::DomDocument::DomDocument(std::wstring const &filename)
 {
     init();
 
-    BSTR bstrValue{bstr_t(filename.c_str())};
+    BSTR bstrValue{static_cast<_bstr_t>(filename.c_str())};
     CComVariant value(bstrValue);
 
     VARIANT_BOOL resultCode = FALSE;
@@ -27,10 +27,8 @@ Linter::DomDocument::DomDocument(std::string const &xml)
 {
     init();
 
-    BSTR bstrValue{(bstr_t(xml.c_str()))};
-
     VARIANT_BOOL resultCode = FALSE;
-    HRESULT hr = m_document->loadXML(bstrValue, &resultCode);
+    HRESULT hr = m_document->loadXML(static_cast<_bstr_t>(xml.c_str()), &resultCode);
 
     checkLoadResults(resultCode, hr);
 }
@@ -40,7 +38,7 @@ Linter::DomDocument::~DomDocument() = default;
 CComPtr<IXMLDOMNodeList> Linter::DomDocument::getNodeList(std::string const &xpath)
 {
     CComPtr<IXMLDOMNodeList> nodes;
-    HRESULT hr = m_document->selectNodes(bstr_t(xpath.c_str()), &nodes);
+    HRESULT hr = m_document->selectNodes(static_cast<_bstr_t>(xpath.c_str()), &nodes);
     if (!SUCCEEDED(hr))
     {
         throw SystemError(hr, "Can't execute XPath " + xpath);

--- a/DomDocument.h
+++ b/DomDocument.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <msxml6.h>
+#include <wtypes.h>
+
+namespace Linter
+{
+    class DomDocument
+    {
+        /** Importamnt note:
+         * The wstring constructor takes a filename.
+         * The string constructor takes an xml string.
+         */
+      public:
+        /** Creates an XML document from the supplied filename */
+        explicit DomDocument(std::wstring const &filename);
+
+        /** Creates an XML document from the supplied UTF8 string */
+        explicit DomDocument(std::string const &xml);
+
+        ~DomDocument();
+
+        /** Get list of nodes select by an XPATH */
+        CComPtr<IXMLDOMNodeList> getNodeList(std::string const &xpath);
+
+      private:
+        /** Set up the dom interface */
+        void init();
+
+        /* Check the result of doing a load, die if it didn't complete */
+        void checkLoadResults(VARIANT_BOOL resultcode, HRESULT hr, std::string const & filename);
+
+        CComPtr<IXMLDOMDocument2> m_document;
+    };
+
+}    // namespace Linter

--- a/DomDocument.h
+++ b/DomDocument.h
@@ -22,6 +22,11 @@ namespace Linter
         /** Creates an XML document from the supplied UTF8 string */
         explicit DomDocument(std::string const &xml);
 
+        DomDocument(DomDocument const &) = delete;
+        DomDocument(DomDocument &&) = delete;
+        DomDocument &operator=(DomDocument const &) = delete;
+        DomDocument &operator=(DomDocument &&) = delete;
+
         ~DomDocument();
 
         /** Get list of nodes selected by supplied XPATH */

--- a/DomDocument.h
+++ b/DomDocument.h
@@ -14,6 +14,7 @@ namespace Linter
          * The wstring constructor takes a filename.
          * The string constructor takes an xml string.
          */
+
       public:
         /** Creates an XML document from the supplied filename */
         explicit DomDocument(std::wstring const &filename);
@@ -23,7 +24,7 @@ namespace Linter
 
         ~DomDocument();
 
-        /** Get list of nodes select by an XPATH */
+        /** Get list of nodes selected by supplied XPATH */
         CComPtr<IXMLDOMNodeList> getNodeList(std::string const &xpath);
 
       private:
@@ -31,7 +32,7 @@ namespace Linter
         void init();
 
         /* Check the result of doing a load, die if it didn't complete */
-        void checkLoadResults(VARIANT_BOOL resultcode, HRESULT hr, std::string const & filename);
+        void checkLoadResults(VARIANT_BOOL resultcode, HRESULT hr);
 
         CComPtr<IXMLDOMDocument2> m_document;
     };

--- a/XmlDecodeException.cpp
+++ b/XmlDecodeException.cpp
@@ -1,0 +1,53 @@
+#include "stdafx.h"
+#include "XmlDecodeException.h"
+
+#include <MsXml6.h>
+
+#include <cstdio>
+
+namespace Linter
+{
+
+    XmlDecodeException::XmlDecodeException(IXMLDOMParseError *error)
+    {
+        // Note that this constructor does allocations. Sorry.
+
+        //Get the error line and column for later.
+        error->get_line(&m_line);
+        error->get_linepos(&m_column);
+
+        //We use the rest of the information to construct the what message.
+        BSTR url;
+        error->get_url(&url);
+
+        std::size_t pos = std::snprintf(m_buff,
+            sizeof(m_buff),
+            "Invalid xml in %s at line %ld col %ld",
+            url == nullptr ? "temporary linter output file" : static_cast<std::string>(static_cast<bstr_t>(url)).c_str(),
+            m_line,
+            m_column);
+
+        BSTR text;
+        error->get_srcText(&text);
+        if (text != nullptr)
+        {
+            pos += std::snprintf(
+                m_buff + pos, sizeof(m_buff) - pos, " (near %s)", static_cast<std::string>(static_cast<bstr_t>(text)).c_str());
+        }
+
+        long code;
+        error->get_errorCode(&code);
+        BSTR reason;
+        error->get_reason(&reason);
+        std::snprintf(
+            m_buff + pos, sizeof(m_buff) - pos, ": code %08lx %s", code, static_cast<std::string>(static_cast<bstr_t>(reason)).c_str());
+    }
+
+    XmlDecodeException::~XmlDecodeException() = default;
+
+    char const *XmlDecodeException::what() const noexcept
+    {
+        return &m_buff[0];
+    }
+
+}    // namespace Linter

--- a/XmlDecodeException.cpp
+++ b/XmlDecodeException.cpp
@@ -20,7 +20,7 @@ Linter::XmlDecodeException::XmlDecodeException(IXMLDOMParseError *error)
     std::size_t pos = std::snprintf(m_buff,
         sizeof(m_buff),
         "Invalid xml in %s at line %ld col %ld",
-        url == nullptr ? "temporary linter output file" : static_cast<std::string>(static_cast<bstr_t>(url)).c_str(),
+        url == nullptr ? "temporary linter output file" : static_cast<char *>(static_cast<_bstr_t>(url)),
         m_line,
         m_column);
 
@@ -28,7 +28,7 @@ Linter::XmlDecodeException::XmlDecodeException(IXMLDOMParseError *error)
     error->get_srcText(&text);
     if (text != nullptr)
     {
-        pos += std::snprintf(m_buff + pos, sizeof(m_buff) - pos, " (near %s)", static_cast<std::string>(static_cast<bstr_t>(text)).c_str());
+        pos += std::snprintf(m_buff + pos, sizeof(m_buff) - pos, " (near %s)", static_cast<char *>(static_cast<_bstr_t>(text)));
     }
 
     long code;
@@ -36,7 +36,7 @@ Linter::XmlDecodeException::XmlDecodeException(IXMLDOMParseError *error)
     BSTR reason;
     error->get_reason(&reason);
     std::snprintf(
-        m_buff + pos, sizeof(m_buff) - pos, ": code %08lx %s", code, static_cast<std::string>(static_cast<bstr_t>(reason)).c_str());
+        m_buff + pos, sizeof(m_buff) - pos, ": code %08lx %s", code, static_cast<char *>(static_cast<_bstr_t>(reason)));
 }
 
 Linter::XmlDecodeException::~XmlDecodeException() = default;

--- a/XmlDecodeException.cpp
+++ b/XmlDecodeException.cpp
@@ -5,49 +5,43 @@
 
 #include <cstdio>
 
-namespace Linter
+Linter::XmlDecodeException::XmlDecodeException(IXMLDOMParseError *error)
 {
+    // Note that this constructor does allocations. Sorry.
 
-    XmlDecodeException::XmlDecodeException(IXMLDOMParseError *error)
+    //Get the error line and column for later.
+    error->get_line(&m_line);
+    error->get_linepos(&m_column);
+
+    //We use the rest of the information to construct the what message.
+    BSTR url;
+    error->get_url(&url);
+
+    std::size_t pos = std::snprintf(m_buff,
+        sizeof(m_buff),
+        "Invalid xml in %s at line %ld col %ld",
+        url == nullptr ? "temporary linter output file" : static_cast<std::string>(static_cast<bstr_t>(url)).c_str(),
+        m_line,
+        m_column);
+
+    BSTR text;
+    error->get_srcText(&text);
+    if (text != nullptr)
     {
-        // Note that this constructor does allocations. Sorry.
-
-        //Get the error line and column for later.
-        error->get_line(&m_line);
-        error->get_linepos(&m_column);
-
-        //We use the rest of the information to construct the what message.
-        BSTR url;
-        error->get_url(&url);
-
-        std::size_t pos = std::snprintf(m_buff,
-            sizeof(m_buff),
-            "Invalid xml in %s at line %ld col %ld",
-            url == nullptr ? "temporary linter output file" : static_cast<std::string>(static_cast<bstr_t>(url)).c_str(),
-            m_line,
-            m_column);
-
-        BSTR text;
-        error->get_srcText(&text);
-        if (text != nullptr)
-        {
-            pos += std::snprintf(
-                m_buff + pos, sizeof(m_buff) - pos, " (near %s)", static_cast<std::string>(static_cast<bstr_t>(text)).c_str());
-        }
-
-        long code;
-        error->get_errorCode(&code);
-        BSTR reason;
-        error->get_reason(&reason);
-        std::snprintf(
-            m_buff + pos, sizeof(m_buff) - pos, ": code %08lx %s", code, static_cast<std::string>(static_cast<bstr_t>(reason)).c_str());
+        pos += std::snprintf(m_buff + pos, sizeof(m_buff) - pos, " (near %s)", static_cast<std::string>(static_cast<bstr_t>(text)).c_str());
     }
 
-    XmlDecodeException::~XmlDecodeException() = default;
+    long code;
+    error->get_errorCode(&code);
+    BSTR reason;
+    error->get_reason(&reason);
+    std::snprintf(
+        m_buff + pos, sizeof(m_buff) - pos, ": code %08lx %s", code, static_cast<std::string>(static_cast<bstr_t>(reason)).c_str());
+}
 
-    char const *XmlDecodeException::what() const noexcept
-    {
-        return &m_buff[0];
-    }
+Linter::XmlDecodeException::~XmlDecodeException() = default;
 
-}    // namespace Linter
+char const *Linter::XmlDecodeException::what() const noexcept
+{
+    return &m_buff[0];
+}

--- a/XmlDecodeException.cpp
+++ b/XmlDecodeException.cpp
@@ -39,6 +39,8 @@ Linter::XmlDecodeException::XmlDecodeException(IXMLDOMParseError *error)
         m_buff + pos, sizeof(m_buff) - pos, ": code %08lx %s", code, static_cast<char *>(static_cast<_bstr_t>(reason)));
 }
 
+Linter::XmlDecodeException::XmlDecodeException(XmlDecodeException &&) noexcept = default;
+
 Linter::XmlDecodeException::~XmlDecodeException() = default;
 
 char const *Linter::XmlDecodeException::what() const noexcept

--- a/XmlDecodeException.h
+++ b/XmlDecodeException.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <exception>
+#include <string>
+
+struct IXMLDOMParseError;
+
+namespace Linter
+{
+    class XmlDecodeException : public std::exception
+    {
+      public:
+        explicit XmlDecodeException(IXMLDOMParseError *);
+
+        ~XmlDecodeException();
+
+        char const *what() const noexcept override;
+
+      private:
+        //value of what()
+        char m_buff[2048];
+
+        //Line at which error detected
+        long m_line;
+
+        //Column at which error detected
+        long m_column;
+    };
+}    // namespace Linter

--- a/XmlDecodeException.h
+++ b/XmlDecodeException.h
@@ -11,6 +11,10 @@ namespace Linter
       public:
         explicit XmlDecodeException(IXMLDOMParseError *);
 
+        XmlDecodeException(XmlDecodeException const &) = delete;
+        XmlDecodeException(XmlDecodeException &&) noexcept;
+        XmlDecodeException &operator=(XmlDecodeException const &) = delete;
+        XmlDecodeException &operator=(XmlDecodeException &&) = delete;
         ~XmlDecodeException();
 
         char const *what() const noexcept override;

--- a/XmlParser.cpp
+++ b/XmlParser.cpp
@@ -1,246 +1,149 @@
 #include "stdafx.h"
 #include "XmlParser.h"
-#include "encoding.h"
+
+#include "DomDocument.h"
 #include "SystemError.h"
+#include "encoding.h"
+
+#include <memory>
+#include <sstream>
 
 #include <msxml6.h>
-#pragma comment(lib, "msxml6.lib")
 
-#define RELEASE(iface)    \
-    if (iface)            \
-    {                     \
-        iface->Release(); \
-        iface = NULL;     \
-    }
+using Linter::SystemError;
 
 std::vector<XmlParser::Error> XmlParser::getErrors(const std::string &xml)
 {
+    ::Linter::DomDocument XMLDocument(xml);
+    // <error line="12" column="19" severity="error" message="Unexpected identifier" source="jscs" />
+
     std::vector<XmlParser::Error> errors;
-    IXMLDOMNodeList *XMLNodeList(NULL);
-    IXMLDOMNode *XMLNode(NULL);
-    IXMLDOMDocument2 *XMLDocument(NULL);
-    HRESULT hr;
 
-    try
+    CComPtr<IXMLDOMNodeList> XMLNodeList{XMLDocument.getNodeList("//error")};
+
+    //Why do we need uLength if we're using nextNode?
+    LONG uLength;
+    HRESULT hr = XMLNodeList->get_length(&uLength);
+    if (!SUCCEEDED(hr))
     {
-        hr = CoCreateInstance(__uuidof(DOMDocument), NULL, CLSCTX_SERVER, IID_IXMLDOMDocument2, (LPVOID *)(&XMLDocument));
-        if (!SUCCEEDED(hr) || !XMLDocument)
-        {
-            throw ::Linter::SystemError("Linter: Can't create IID_IXMLDOMDocument2");
-        }
-
-        hr = XMLDocument->put_async(VARIANT_FALSE);
-        if (!SUCCEEDED(hr))
-        {
-            throw ::Linter::SystemError("Linter: Can't XMLDOMDocument2::put_async");
-        }
-
-        const std::wstring &string = Encoding::toUnicode(xml);
-        BSTR bstrValue(bstr_t(string.c_str()));
-
-        short resultCode = FALSE;
-        hr = XMLDocument->loadXML(bstrValue, &resultCode);
-        if (!SUCCEEDED(hr) || (resultCode != VARIANT_TRUE))
-        {
-            throw ::Linter::SystemError("Linter: Invalid output format. Only checkstyle-compatible output allowed.");
-        }
-
-        // <error line="12" column="19" severity="error" message="Unexpected identifier" source="jscs" />
-        hr = XMLDocument->selectNodes(bstr_t(L"//error"), &XMLNodeList);
-        if (!SUCCEEDED(hr))
-        {
-            throw ::Linter::SystemError("Linter: Can't execute XPath //error");
-        }
-        LONG uLength;
-
-        hr = XMLNodeList->get_length(&uLength);
-        if (!SUCCEEDED(hr))
-        {
-            throw ::Linter::SystemError("Linter: Can't get XPath //error length");
-        }
-        for (int iIndex = 0; iIndex < uLength; iIndex++)
-        {
-            IXMLDOMNode *node;
-            hr = XMLNodeList->nextNode(&node);
-            if (!SUCCEEDED(hr))
-            {
-                throw ::Linter::SystemError("Linter: Can't get next XPath element");
-            }
-            CComQIPtr<IXMLDOMElement> element(node);
-            if (!SUCCEEDED(hr) && element)
-            {
-                throw ::Linter::SystemError("Linter: XPath Element error");
-            }
-            Error error;
-            CComVariant value;
-
-            element->getAttribute(bstr_t(L"line"), &value);
-            error.m_line = _wtoi(value.bstrVal);
-
-            element->getAttribute(bstr_t(L"column"), &value);
-            error.m_column = _wtoi(value.bstrVal);
-
-            element->getAttribute(bstr_t(L"message"), &value);
-            error.m_message = value.bstrVal;
-
-            errors.push_back(error);
-            RELEASE(node);
-        }
-        RELEASE(XMLNodeList);
-        RELEASE(XMLDocument);
+        throw SystemError(hr, "Can't get XPath //error length");
     }
-    catch (::Linter::SystemError &)
+    for (int iIndex = 0; iIndex < uLength; iIndex++)
     {
-        RELEASE(XMLNode);
-        RELEASE(XMLDocument);
-        RELEASE(XMLNodeList);
+        CComPtr<IXMLDOMNode> node;
+        hr = XMLNodeList->nextNode(&node);
+        if (!SUCCEEDED(hr))
+        {
+            throw SystemError(hr, "Can't get next XPath element");
+        }
 
-        throw;
-    }
-    catch (...)
-    {
-        RELEASE(XMLNode);
-        RELEASE(XMLDocument);
-        RELEASE(XMLNodeList);
+        CComQIPtr<IXMLDOMElement> element(node);
+        Error error;
+        CComVariant value;
+
+        element->getAttribute(bstr_t(L"line"), &value);
+        error.m_line = std::stoi(value.bstrVal);
+
+        element->getAttribute(bstr_t(L"column"), &value);
+        error.m_column = std::stoi(value.bstrVal);
+
+        element->getAttribute(bstr_t(L"message"), &value);
+        error.m_message = value.bstrVal;
+
+        errors.push_back(error);
     }
 
     return errors;
 }
 
-XmlParser::Settings XmlParser::getLinters(std::wstring file)
+XmlParser::Settings XmlParser::getLinters(std::wstring const &file)
 {
     XmlParser::Settings settings;
-    IXMLDOMNodeList *XMLNodeList(NULL), *styleNode(NULL);
-    IXMLDOMNode *XMLNode(NULL);
-    IXMLDOMDocument2 *XMLDocument(NULL);
-    HRESULT hr;
+    ::Linter::DomDocument XMLDocument(file);
+    CComPtr<IXMLDOMNodeList> styleNode{XMLDocument.getNodeList("//style")};
+
+    //Why do we need to get the length if we're going to use nextNode?
     LONG uLength;
-
-    try
+    HRESULT hr = styleNode->get_length(&uLength);
+    if (!SUCCEEDED(hr))
     {
-        hr = CoCreateInstance(__uuidof(DOMDocument), NULL, CLSCTX_SERVER, IID_IXMLDOMDocument2, (LPVOID *)(&XMLDocument));
-        if (!SUCCEEDED(hr) || !XMLDocument)
-        {
-            throw ::Linter::SystemError("Linter: Can't create IID_IXMLDOMDocument2");
-        }
-
-        hr = XMLDocument->put_async(VARIANT_FALSE);
-        if (!SUCCEEDED(hr))
-        {
-            throw ::Linter::SystemError("Linter: XMLDOMDocument2::put_async error.");
-        }
-
-        BSTR bstrValue(bstr_t(file.c_str()));
-        CComVariant value(bstrValue);
-
-        short resultCode = FALSE;
-        hr = XMLDocument->load(value, &resultCode);
-        if (!SUCCEEDED(hr) || (resultCode != VARIANT_TRUE))
-        {
-            throw ::Linter::SystemError("Linter: linter.xml load error. Check file format.");
-        }
-
-        hr = XMLDocument->selectNodes(bstr_t(L"//style"), &styleNode);
-        if (!SUCCEEDED(hr))
-        {
-            throw ::Linter::SystemError("Linter: Can't execute XPath //style");
-        }
-
-        hr = styleNode->get_length(&uLength);
-        if (!SUCCEEDED(hr))
-        {
-            throw ::Linter::SystemError("Linter: Can't get XPath root length");
-        }
-        else if (uLength)
-        {
-            IXMLDOMNode *node;
-            hr = styleNode->nextNode(&node);
-            if (SUCCEEDED(hr))
-            {
-                CComQIPtr<IXMLDOMElement> element(node);
-
-                CComVariant alpha;
-                if (element->getAttribute(bstr_t(L"alpha"), &alpha) == S_OK)
-                {
-                    std::wstringstream data(std::wstring(alpha.bstrVal ? alpha.bstrVal : L""));
-                    data >> settings.m_alpha;
-                }
-
-                if (element->getAttribute(bstr_t(L"color"), &alpha) == S_OK)
-                {
-                    std::wstringstream data(std::wstring(alpha.bstrVal ? alpha.bstrVal : L""));
-                    unsigned int color(0);
-                    data >> std::hex >> color;
-
-                    // reverse colors for scintilla's LE order
-                    settings.m_color = color & 0xFF;
-
-                    settings.m_color <<= 8;
-                    color >>= 8;
-                    settings.m_color |= color & 0xFF;
-
-                    settings.m_color <<= 8;
-                    color >>= 8;
-                    settings.m_color |= color & 0xFF;
-                }
-            }
-        }
-
-        // <error line="12" column="19" severity="error" message="Unexpected identifier" source="jscs" />
-        hr = XMLDocument->selectNodes(bstr_t(L"//linter"), &XMLNodeList);
-        if (!SUCCEEDED(hr))
-        {
-            throw ::Linter::SystemError("Linter: Can't execute XPath //linter");
-        }
-
-        hr = XMLNodeList->get_length(&uLength);
-        if (!SUCCEEDED(hr))
-        {
-            throw ::Linter::SystemError("Linter: Can't get XPath length");
-        }
-
-        for (int iIndex = 0; iIndex < uLength; iIndex++)
-        {
-            IXMLDOMNode *node;
-            hr = XMLNodeList->nextNode(&node);
-            if (SUCCEEDED(hr))
-            {
-                CComQIPtr<IXMLDOMElement> element(node);
-                if (SUCCEEDED(hr) && element)
-                {
-                    Linter linter;
-                    CComVariant extension;
-
-                    element->getAttribute(bstr_t(L"extension"), &extension);
-                    linter.m_extension = extension.bstrVal;
-
-                    element->getAttribute(bstr_t(L"command"), &extension);
-                    linter.m_command = extension.bstrVal;
-
-                    element->getAttribute(bstr_t(L"stdin"), &extension);
-                    linter.m_useStdin = !!extension.boolVal;
-
-                    settings.m_linters.push_back(linter);
-                }
-                RELEASE(node);
-            }
-        }
-        RELEASE(XMLNodeList);
-        RELEASE(XMLDocument);
+        throw SystemError(hr, "Can't get XPath style length");
     }
-    catch (::Linter::SystemError &)
-    {
-        RELEASE(XMLNode);
-        RELEASE(XMLDocument);
-        RELEASE(XMLNodeList);
 
-        throw;
-    }
-    catch (...)
+    if (uLength != 0)
     {
-        RELEASE(XMLNode);
-        RELEASE(XMLDocument);
-        RELEASE(XMLNodeList);
+        CComPtr<IXMLDOMNode> node;
+        hr = styleNode->nextNode(&node);
+        if (!SUCCEEDED(hr))
+        {
+            throw SystemError(hr, "Can't read style node");
+        }
+        CComQIPtr<IXMLDOMElement> element(node);
+        CComVariant value;
+        if (element->getAttribute(bstr_t(L"alpha"), &value) == S_OK)
+        {
+            int alpha = 0;
+            if (value.bstrVal)
+            {
+                std::wstringstream data{std::wstring(value.bstrVal, SysStringLen(value.bstrVal))};
+                data >> alpha;
+            }
+            settings.m_alpha = alpha;
+        }
+
+        if (element->getAttribute(bstr_t(L"color"), &value) == S_OK)
+        {
+            unsigned int color(0);
+            if (value.bstrVal)
+            {
+                std::wstringstream data{std::wstring(value.bstrVal, SysStringLen(value.bstrVal))};
+                data >> std::hex >> color;
+            }
+
+            // reverse colors for scintilla's LE order
+            settings.m_color = color & 0xFF;
+
+            settings.m_color <<= 8;
+            color >>= 8;
+            settings.m_color |= color & 0xFF;
+
+            settings.m_color <<= 8;
+            color >>= 8;
+            settings.m_color |= color & 0xFF;
+        }
+    }
+
+    // <error line="12" column="19" severity="error" message="Unexpected identifier" source="jscs" />
+    CComPtr<IXMLDOMNodeList> XMLNodeList{XMLDocument.getNodeList("//linter")};
+
+    //Why do we need to get the length if we're going to use nextNode?
+    hr = XMLNodeList->get_length(&uLength);
+    if (!SUCCEEDED(hr))
+    {
+        throw SystemError(hr, "Can't get XPath length");
+    }
+
+    for (int iIndex = 0; iIndex < uLength; iIndex++)
+    {
+        CComPtr<IXMLDOMNode> node;
+        hr = XMLNodeList->nextNode(&node);
+        if (SUCCEEDED(hr) && node != nullptr)
+        {
+            CComQIPtr<IXMLDOMElement> element(node);
+            Linter linter;
+            CComVariant extension;
+
+            element->getAttribute(bstr_t(L"extension"), &extension);
+            linter.m_extension = extension.bstrVal;
+
+            element->getAttribute(bstr_t(L"command"), &extension);
+            linter.m_command = extension.bstrVal;
+
+            element->getAttribute(bstr_t(L"stdin"), &extension);
+            linter.m_useStdin = !!extension.boolVal;
+
+            settings.m_linters.push_back(linter);
+        }
     }
 
     return settings;

--- a/XmlParser.cpp
+++ b/XmlParser.cpp
@@ -40,13 +40,13 @@ std::vector<XmlParser::Error> XmlParser::getErrors(const std::string &xml)
         Error error;
         CComVariant value;
 
-        element->getAttribute(L"line", &value);
+        element->getAttribute(bstr_t(L"line"), &value);
         error.m_line = std::stoi(value.bstrVal);
 
-        element->getAttribute(L"column", &value);
+        element->getAttribute(bstr_t(L"column"), &value);
         error.m_column = std::stoi(value.bstrVal);
 
-        element->getAttribute(L"message", &value);
+        element->getAttribute(bstr_t(L"message"), &value);
         error.m_message = value.bstrVal;
 
         errors.push_back(error);
@@ -78,7 +78,7 @@ XmlParser::Settings XmlParser::getLinters(std::wstring const &file)
         }
         CComQIPtr<IXMLDOMElement> element(node);
         CComVariant value;
-        if (element->getAttribute(L"alpha", &value) == S_OK)
+        if (element->getAttribute(bstr_t(L"alpha"), &value) == S_OK)
         {
             int alpha = 0;
             if (value.bstrVal)
@@ -89,7 +89,7 @@ XmlParser::Settings XmlParser::getLinters(std::wstring const &file)
             settings.m_alpha = alpha;
         }
 
-        if (element->getAttribute(L"color", &value) == S_OK)
+        if (element->getAttribute(bstr_t(L"color"), &value) == S_OK)
         {
             unsigned int color(0);
             if (value.bstrVal)
@@ -130,13 +130,13 @@ XmlParser::Settings XmlParser::getLinters(std::wstring const &file)
             Linter linter;
             CComVariant extension;
 
-            element->getAttribute(L"extension", &extension);
+            element->getAttribute(bstr_t(L"extension"), &extension);
             linter.m_extension = extension.bstrVal;
 
-            element->getAttribute(L"command", &extension);
+            element->getAttribute(bstr_t(L"command"), &extension);
             linter.m_command = extension.bstrVal;
 
-            element->getAttribute(L"stdin", &extension);
+            element->getAttribute(bstr_t(L"stdin"), &extension);
             linter.m_useStdin = !!extension.boolVal;
 
             settings.m_linters.push_back(linter);

--- a/XmlParser.cpp
+++ b/XmlParser.cpp
@@ -40,13 +40,13 @@ std::vector<XmlParser::Error> XmlParser::getErrors(const std::string &xml)
         Error error;
         CComVariant value;
 
-        element->getAttribute(bstr_t(L"line"), &value);
+        element->getAttribute(L"line", &value);
         error.m_line = std::stoi(value.bstrVal);
 
-        element->getAttribute(bstr_t(L"column"), &value);
+        element->getAttribute(L"column", &value);
         error.m_column = std::stoi(value.bstrVal);
 
-        element->getAttribute(bstr_t(L"message"), &value);
+        element->getAttribute(L"message", &value);
         error.m_message = value.bstrVal;
 
         errors.push_back(error);
@@ -78,7 +78,7 @@ XmlParser::Settings XmlParser::getLinters(std::wstring const &file)
         }
         CComQIPtr<IXMLDOMElement> element(node);
         CComVariant value;
-        if (element->getAttribute(bstr_t(L"alpha"), &value) == S_OK)
+        if (element->getAttribute(L"alpha", &value) == S_OK)
         {
             int alpha = 0;
             if (value.bstrVal)
@@ -89,7 +89,7 @@ XmlParser::Settings XmlParser::getLinters(std::wstring const &file)
             settings.m_alpha = alpha;
         }
 
-        if (element->getAttribute(bstr_t(L"color"), &value) == S_OK)
+        if (element->getAttribute(L"color", &value) == S_OK)
         {
             unsigned int color(0);
             if (value.bstrVal)
@@ -130,13 +130,13 @@ XmlParser::Settings XmlParser::getLinters(std::wstring const &file)
             Linter linter;
             CComVariant extension;
 
-            element->getAttribute(bstr_t(L"extension"), &extension);
+            element->getAttribute(L"extension", &extension);
             linter.m_extension = extension.bstrVal;
 
-            element->getAttribute(bstr_t(L"command"), &extension);
+            element->getAttribute(L"command", &extension);
             linter.m_command = extension.bstrVal;
 
-            element->getAttribute(bstr_t(L"stdin"), &extension);
+            element->getAttribute(L"stdin", &extension);
             linter.m_useStdin = !!extension.boolVal;
 
             settings.m_linters.push_back(linter);

--- a/XmlParser.cpp
+++ b/XmlParser.cpp
@@ -21,7 +21,6 @@ std::vector<XmlParser::Error> XmlParser::getErrors(const std::string &xml)
 
     CComPtr<IXMLDOMNodeList> XMLNodeList{XMLDocument.getNodeList("//error")};
 
-    //Why do we need uLength if we're using nextNode?
     LONG uLength;
     HRESULT hr = XMLNodeList->get_length(&uLength);
     if (!SUCCEEDED(hr))
@@ -62,7 +61,6 @@ XmlParser::Settings XmlParser::getLinters(std::wstring const &file)
     ::Linter::DomDocument XMLDocument(file);
     CComPtr<IXMLDOMNodeList> styleNode{XMLDocument.getNodeList("//style")};
 
-    //Why do we need to get the length if we're going to use nextNode?
     LONG uLength;
     HRESULT hr = styleNode->get_length(&uLength);
     if (!SUCCEEDED(hr))
@@ -116,7 +114,6 @@ XmlParser::Settings XmlParser::getLinters(std::wstring const &file)
     // <error line="12" column="19" severity="error" message="Unexpected identifier" source="jscs" />
     CComPtr<IXMLDOMNodeList> XMLNodeList{XMLDocument.getNodeList("//linter")};
 
-    //Why do we need to get the length if we're going to use nextNode?
     hr = XMLNodeList->get_length(&uLength);
     if (!SUCCEEDED(hr))
     {

--- a/XmlParser.h
+++ b/XmlParser.h
@@ -32,5 +32,5 @@ class XmlParser
     };
 
     static std::vector<Error> getErrors(const std::string &xml);
-    static Settings getLinters(std::wstring file);
+    static Settings getLinters(std::wstring const &file);
 };

--- a/linter.vcxproj
+++ b/linter.vcxproj
@@ -183,6 +183,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="SystemError.cpp" />
+    <ClCompile Include="XmlDecodeException.cpp" />
     <ClCompile Include="XmlParser.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -202,6 +203,7 @@
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="SystemError.h" />
     <ClInclude Include="targetver.h" />
+    <ClInclude Include="XmlDecodeException.h" />
     <ClInclude Include="XmlParser.h" />
   </ItemGroup>
   <ItemGroup>

--- a/linter.vcxproj
+++ b/linter.vcxproj
@@ -169,6 +169,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="DomDocument.cpp" />
     <ClCompile Include="encoding.cpp" />
     <ClCompile Include="file.cpp" />
     <ClCompile Include="FilePipe.cpp" />
@@ -185,6 +186,7 @@
     <ClCompile Include="XmlParser.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="DomDocument.h" />
     <ClInclude Include="encoding.h" />
     <ClInclude Include="file.h" />
     <ClInclude Include="FilePipe.h" />

--- a/linter.vcxproj.filters
+++ b/linter.vcxproj.filters
@@ -35,6 +35,9 @@
     <ClCompile Include="SystemError.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DomDocument.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="HandleWrapper.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -65,6 +68,9 @@
       <Filter>Source Files</Filter>
     </ClInclude>
     <ClInclude Include="FilePipe.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="DomDocument.h">
       <Filter>Source Files</Filter>
     </ClInclude>
     <ClInclude Include="HandleWrapper.h">

--- a/linter.vcxproj.filters
+++ b/linter.vcxproj.filters
@@ -3,7 +3,7 @@
   <ItemGroup>
     <Filter Include="Source Files">
       <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
-      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx;h;hpp</Extensions>
     </Filter>
     <Filter Include="Resource Files">
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
@@ -42,6 +42,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="FilePipe.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="XmlDecodeException.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -95,6 +98,9 @@
       <Filter>Source Files</Filter>
     </ClInclude>
     <ClInclude Include="targetver.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="XmlDecodeException.h">
       <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -117,7 +117,7 @@ bool setCommand(size_t index, TCHAR *cmdName, PFUNCPLUGINCMD pFunc, ShortcutKey 
 
 void commandMenuInit()
 {
-    setCommand(0, bstr_t(L"Edit config"), editConfig, NULL, false);
+    setCommand(0, L"Edit config", editConfig, NULL, false);
 }
 
 void commandMenuCleanUp()

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -117,7 +117,7 @@ bool setCommand(size_t index, TCHAR *cmdName, PFUNCPLUGINCMD pFunc, ShortcutKey 
 
 void commandMenuInit()
 {
-    setCommand(0, L"Edit config", editConfig, NULL, false);
+    setCommand(0, bstr_t(L"Edit config"), editConfig, NULL, false);
 }
 
 void commandMenuCleanUp()

--- a/stdafx.h
+++ b/stdafx.h
@@ -20,6 +20,3 @@
 #include <atlstr.h>
 #include <ATLCom.h>
 #include <comdef.h>
-#include <exception>
-#include <string>
-#include <sstream>


### PR DESCRIPTION
This factors out the common code of the xml parsers to use a more exception friendly class with improved error reporting when there's a problem with the xml (the later being useful for the option of having a docked window), and make appropriate use of CComPtr

It also reintroduces the double catch so that failures with a command don't stop other commands being run for the extension whereas other errors (very probably writing a temp file) will still get caught and logged rather than resulting in an uncaught exception.

Finally I added .h to the source code extensions as the header view in the project was removed.

Note: The comparison works better with white space ignored.